### PR TITLE
Allow passing Popper modifiers as props.

### DIFF
--- a/src/Popover.js
+++ b/src/Popover.js
@@ -32,6 +32,7 @@ class Popover extends React.Component {
       arrow,
       onClick,
       placement,
+      modifiers,
       render,
       action,
       motion,
@@ -60,6 +61,7 @@ class Popover extends React.Component {
             customArrow={customArrow}
             onClosePopover={this.closePopover}
             placement={placement}
+            modifiers={modifiers}
             {...this.props}
             id={this.state.id}
           />
@@ -73,6 +75,7 @@ Popover.defaultProps = {
   arrow: true,
   placement: "auto",
   action: "click",
+  modifiers: {},
   motion: false,
   className: undefined,
   isOpen: false

--- a/src/PopoverComponent.js
+++ b/src/PopoverComponent.js
@@ -69,10 +69,10 @@ export default class PopoverComponent extends React.Component {
   }
 
   render() {
-    const { placement, arrow, className, motion, id, customArrow, children } = this.props;
+    const { placement, modifiers, arrow, className, motion, id, customArrow, children } = this.props;
 
     return (
-      <Popper placement={placement} ref="popover">
+      <Popper placement={placement} modifiers={modifiers} ref="popover">
         {({ popperProps }) => {
           popperProps.className = "popover-content";
           if (arrow) {


### PR DESCRIPTION
While using react-awesome-popover I noticed that the placement of the popover was in some situations outside the viewport. Popper.js (react-popper) can solve that, but it needs a modifiers object to be passed. An example modifier object that solved my issue:

```javascript
{
  preventOverflow: {
    boundariesElement: 'viewport'
  }
}
```