### PR TITLE
Do not pass ref to popper

### DIFF
--- a/src/PopoverComponent.js
+++ b/src/PopoverComponent.js
@@ -6,10 +6,7 @@ import Overlay from './Overlay';
 
 export default class PopoverComponent extends React.Component {
   componentWillUnmount() {
-    const { action, onClose } = this.props;
-    if (action === 'hover') {
-      this.refs.popover._node.removeEventListener('mouseleave', this.ms, false);
-    }
+    const { onClose } = this.props;
 
     if (onClose) onClose();
   }
@@ -17,10 +14,7 @@ export default class PopoverComponent extends React.Component {
   ms = ({ relatedTarget }) => isOverlay(relatedTarget) && this.props.onClosePopover();
 
   componentDidMount() {
-    const { action, onOpen } = this.props;
-    if (action === 'hover') {
-      this.refs.popover._node.addEventListener('mouseleave', this.ms, false);
-    }
+    const { onOpen } = this.props;
 
     if (onOpen) onOpen();
   }

--- a/src/PopoverComponent.js
+++ b/src/PopoverComponent.js
@@ -42,7 +42,7 @@ export default class PopoverComponent extends React.Component {
 
     return (
       <React.Fragment>
-        <Popper placement={placement} modifiers={modifiers} ref="popover">
+        <Popper placement={placement} modifiers={modifiers}>
           {({ popperProps }) => {
             let dataPlacement = popperProps['data-placement'];
             let g = dataPlacement && dataPlacement.split('-')[0];


### PR DESCRIPTION
This patch resolves the following error which occurs when using this library in tandem with production React.

```
Invariant Violation: Minified React error #290; visit https://reactjs.org/docs/error-decoder.html?invariant=290&args[]=popover for the full message or use the non-minified dev environment for full errors and additional helpful warnings.
```

AFAICT this change doesn't seem affect the behavior of the component. 😄 